### PR TITLE
SmartHumidityFanComparison enhancements

### DIFF
--- a/Apps/SmartHumidityFanComparison.groovy
+++ b/Apps/SmartHumidityFanComparison.groovy
@@ -95,19 +95,16 @@ def updated()
 def initialize()
 {
 	infolog "Initializing"
-	state.AutomaticallyTurnedOn = false
+	state.AutomaticallyTurnedOn = (FanSwitch.currentValue("switch") == "on")
 	state.TurnOffLaterStarted = false
+	HumidityHandler(null)
+
     subscribe(HumiditySensor, "humidity", HumidityHandler)
     subscribe(CompareHumiditySensor, "humidity", HumidityHandler)
     subscribe(FanSwitch, "switch", FanSwitchHandler)
-	subscribe(location, "mode", modeChangeHandler)
+    subscribe(location, "mode", modeChangeHandler)
+
     version()
-	if (!state.baselineHumidity)
-	{
-        def myHumid = CompareHumiditySensor.currentState("humidity")
-        infolog "${CompareHumiditySensor} currently: ${myHumid.value}"
-		state.baselineHumidity = myHumid.value
-	}
 }
 
 def modeChangeHandler(evt)
@@ -125,18 +122,10 @@ def modeChangeHandler(evt)
 
 def HumidityHandler(evt)
 {
+    state.baselineHumidity = Double.parseDouble(CompareHumiditySensor.currentState("humidity").value.replace("%", ""))
+    state.currentHumidity = Double.parseDouble(HumiditySensor.currentState("humidity").value.replace("%", ""))
     state.threshold = state.baselineHumidity + HumidityIncreasedBy
     state.thresholdOff = state.baselineHumidity + HumidityDecreasedBy
-    if (evt.deviceId == CompareHumiditySensor.deviceId) 
-    {
-        state.baselineHumidity = Double.parseDouble(evt.value.replace("%", ""))
-        //debuglog "Baseline humidity update : ${state.baselineHumidity} from: ${evt.device}"
-    } 
-    else 
-    {
-        state.currentHumidity = Double.parseDouble(evt.value.replace("%", ""))
-        //debuglog "Current humidity update: ${state.currentHumidity} from: ${evt.device}"
-    }
     
     
     //debuglog "TEST: evt: ${evt.descriptionText}"

--- a/Apps/SmartHumidityFanComparison.groovy
+++ b/Apps/SmartHumidityFanComparison.groovy
@@ -103,7 +103,6 @@ def initialize()
 	state.AutomaticallyTurnedOn = (FanSwitch.currentValue("switch") == "on")
 	state.AutomaticallyTurnedOff = !state.AutomaticallyTurnedOn
 	state.TurnOffLaterStarted = false
-	HumidityHandler(null)
 
     subscribe(HumiditySensor, "humidity", HumidityHandler)
     subscribe(CompareHumiditySensor, "humidity", HumidityHandler)
@@ -111,6 +110,8 @@ def initialize()
     subscribe(location, "mode", modeChangeHandler)
 
     version()
+
+	HumidityHandler(null)
 }
 
 def modeChangeHandler(evt)

--- a/Apps/SmartHumidityFanComparison.groovy
+++ b/Apps/SmartHumidityFanComparison.groovy
@@ -133,6 +133,7 @@ def HumidityHandler(evt)
     state.currentHumidity = Double.parseDouble(HumiditySensor.currentState("humidity").value.replace("%", ""))
     state.threshold = state.baselineHumidity + HumidityIncreasedBy
     state.thresholdOff = state.baselineHumidity + HumidityDecreasedBy
+    state.deltaHumidity = Math.round((state.currentHumidity - state.baselineHumidity) * 10) / 10
     
     
     //debuglog "TEST: evt: ${evt.descriptionText}"
@@ -142,8 +143,9 @@ def HumidityHandler(evt)
     //debuglog "TEST: CompareHumiditySensor-ID: ${CompareHumiditySensor.deviceId}"
     debuglog "Current humidity: ${state.currentHumidity}"
     debuglog "Baseline humidity: ${state.baselineHumidity}"
-    debuglog "Turn ON Humidity threshold: ${state.threshold}"
-    debuglog "Turn OFF Humidity threshold: ${state.thresholdOff}"
+    debuglog "Delta humidity: ${state.deltaHumidity}"
+    debuglog "Turn ON Humidity threshold: ${state.threshold} (${HumidityIncreasedBy})"
+    debuglog "Turn OFF Humidity threshold: ${state.thresholdOff}  (${HumidityDecreasedBy})"
     
     //infolog "HumidityHandler:running humidity check: ${state.currentHumidity}"
 	def allModes = settings.modes


### PR DESCRIPTION
The first commit will trigger the humidity handler on initialization and react to the current state of the fan switch. This is useful if the hub reboots or you change configuration settings.

The second commit adds a cool down period in case you want the fan to stay off for a period of time after manually turning off the fan.